### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:17-alpine
 
 WORKDIR /opt/pixel-ping
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:16-alpine
+
+WORKDIR /opt/pixel-ping
+
+# Install node_modules
+COPY package*.json .
+RUN npm install
+
+COPY . .
+
+EXPOSE 9187
+
+CMD [ "/opt/pixel-ping/bin/pixel-ping", "/opt/pixel-ping/config.json" ]


### PR DESCRIPTION
Based on node:16-alpine.

Nothing too interesting to see here. EXPOSE the standard port from the example configuration.

We are expecting here to have the correct config.json mounted at `/opt/pixel-ping/config.json`.